### PR TITLE
Add gitattributes for vpy scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+**/*.vpy linguist-language=Python


### PR DESCRIPTION
This will help fix statistics to recognize vpy files as Python, as well as allow for syntax highlighting to keep things readable